### PR TITLE
LibWeb(WebWorker): Add Web Worker Origin Inheritance

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.cpp
@@ -13,9 +13,10 @@ namespace Web::HTML {
 JS_DEFINE_ALLOCATOR(WorkerEnvironmentSettingsObject);
 
 // https://html.spec.whatwg.org/multipage/workers.html#set-up-a-worker-environment-settings-object
-JS::NonnullGCPtr<WorkerEnvironmentSettingsObject> WorkerEnvironmentSettingsObject::setup(JS::NonnullGCPtr<Page> page, NonnullOwnPtr<JS::ExecutionContext> execution_context /* FIXME: null or an environment reservedEnvironment, a URL topLevelCreationURL, and an origin topLevelOrigin */)
+JS::NonnullGCPtr<WorkerEnvironmentSettingsObject> WorkerEnvironmentSettingsObject::setup(JS::NonnullGCPtr<Page> page, NonnullOwnPtr<JS::ExecutionContext> execution_context, SerializedEnvironmentSettingsObject const& outside_settings, WorkerGlobalScope::WorkerType worker_type)
 {
-    // 1. FIXME: Let inherited origin be outside settings's origin.
+    // 1. Let inherited origin be outside settings's origin.
+    auto inherited_origin = outside_settings.origin;
 
     // 2. Let realm be the value of execution context's Realm component.
     auto realm = execution_context->realm;
@@ -28,9 +29,13 @@ JS::NonnullGCPtr<WorkerEnvironmentSettingsObject> WorkerEnvironmentSettingsObjec
     // NOTE: See the functions defined for this class.
     auto settings_object = realm->heap().allocate<WorkerEnvironmentSettingsObject>(*realm, move(execution_context), worker);
     settings_object->target_browsing_context = nullptr;
+    settings_object->m_origin = move(inherited_origin);
 
     // FIXME: 5. Set settings object's id to a new unique opaque string, creation URL to worker global scope's url, top-level creation URL to null, target browsing context to null, and active service worker to null.
     // FIXME: 6. If worker global scope is a DedicatedWorkerGlobalScope object, then set settings object's top-level origin to outside settings's top-level origin.
+    if (worker_type == WorkerGlobalScope::WorkerType::Dedicated) {
+        settings_object->top_level_origin = outside_settings.top_level_origin;
+    }
     // FIXME: 7. Otherwise, set settings object's top-level origin to an implementation-defined value.
 
     // 8. Set realm's [[HostDefined]] field to settings object.

--- a/Userland/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h
@@ -9,6 +9,7 @@
 #include <LibURL/URL.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/WorkerGlobalScope.h>
 
 namespace Web::HTML {
 
@@ -24,7 +25,7 @@ public:
     {
     }
 
-    static JS::NonnullGCPtr<WorkerEnvironmentSettingsObject> setup(JS::NonnullGCPtr<Page> page, NonnullOwnPtr<JS::ExecutionContext> execution_context /* FIXME: null or an environment reservedEnvironment, a URL topLevelCreationURL, and an origin topLevelOrigin */);
+    static JS::NonnullGCPtr<WorkerEnvironmentSettingsObject> setup(JS::NonnullGCPtr<Page> page, NonnullOwnPtr<JS::ExecutionContext> execution_context, SerializedEnvironmentSettingsObject const& outside_settings, WorkerGlobalScope::WorkerType type);
 
     virtual ~WorkerEnvironmentSettingsObject() override = default;
 

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.h
@@ -41,6 +41,11 @@ class WorkerGlobalScope
     JS_DECLARE_ALLOCATOR(WorkerGlobalScope);
 
 public:
+    enum WorkerType {
+        Dedicated,
+        Shared
+    };
+
     virtual ~WorkerGlobalScope() override;
 
     // ^WindowOrWorkerGlobalScopeMixin

--- a/Userland/Services/WebWorker/DedicatedWorkerHost.cpp
+++ b/Userland/Services/WebWorker/DedicatedWorkerHost.cpp
@@ -52,7 +52,7 @@ void DedicatedWorkerHost::run(JS::NonnullGCPtr<Web::Page> page, Web::HTML::Trans
 
     // 9. Set up a worker environment settings object with realm execution context,
     //    outside settings, and unsafeWorkerCreationTime, and let inside settings be the result.
-    auto inner_settings = Web::HTML::WorkerEnvironmentSettingsObject::setup(page, move(realm_execution_context));
+    auto inner_settings = Web::HTML::WorkerEnvironmentSettingsObject::setup(page, move(realm_execution_context), outside_settings_snapshot, Web::HTML::WorkerGlobalScope::WorkerType::Dedicated);
 
     auto& console_object = *inner_settings->realm().intrinsics().console_object();
     m_console = console_object.heap().allocate_without_realm<Web::HTML::WorkerDebugConsoleClient>(console_object.console());


### PR DESCRIPTION
Fetch requests from web workers fail CORS checks because the origin is not inherited from the outside settings. Ensure web worker origin is correctly inherited from outside settings